### PR TITLE
ThesisCreators should be present in the proposal created by them THS-27 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/thesis/ui/exception/ParticipantNotIncludedException.java
+++ b/src/main/java/org/fenixedu/academic/thesis/ui/exception/ParticipantNotIncludedException.java
@@ -1,0 +1,5 @@
+package org.fenixedu.academic.thesis.ui.exception;
+
+public class ParticipantNotIncludedException extends ThesisProposalException {
+
+}

--- a/src/main/java/org/fenixedu/academic/thesis/ui/service/ThesisProposalsService.java
+++ b/src/main/java/org/fenixedu/academic/thesis/ui/service/ThesisProposalsService.java
@@ -36,6 +36,7 @@ import org.fenixedu.academic.thesis.ui.exception.InvalidPercentageException;
 import org.fenixedu.academic.thesis.ui.exception.InvalidUserException;
 import org.fenixedu.academic.thesis.ui.exception.MaxNumberThesisProposalsException;
 import org.fenixedu.academic.thesis.ui.exception.OutOfProposalPeriodException;
+import org.fenixedu.academic.thesis.ui.exception.ParticipantNotIncludedException;
 import org.fenixedu.academic.thesis.ui.exception.ThesisProposalException;
 import org.fenixedu.academic.thesis.ui.exception.TotalParticipantPercentageException;
 import org.fenixedu.academic.thesis.ui.exception.UnequivalentThesisConfigurationsException;
@@ -197,6 +198,13 @@ public class ThesisProposalsService {
 
         if (participants.isEmpty()) {
             throw new UnexistentThesisParticipantException();
+        }
+
+        User thesisCreator = Authenticate.getUser();
+        if (!proposalBean.getExecutionDegreeSet().stream()
+                .anyMatch(e -> CoordinatorGroup.get(e.getDegree()).isMember(thesisCreator))
+                && !participants.stream().map(bean -> bean.getUser()).anyMatch(u -> u.equals(thesisCreator))) {
+            throw new ParticipantNotIncludedException();
         }
 
         proposalBean.setThesisProposalParticipantsBean(participants);

--- a/src/main/webapp/WEB-INF/resources/ThesisProposalsResources.properties
+++ b/src/main/webapp/WEB-INF/resources/ThesisProposalsResources.properties
@@ -42,6 +42,7 @@ error.thesisProposal.MaxNumberThesisProposalsException = Error: Maximum number o
 error.thesisProposal.NullPointerException = Error: Select thesis proposal no longer available
 error.thesisProposal.OutOfCandidacyPeriodException = Error: Out of candidacy period
 error.thesisProposal.OutOfProposalPeriodException = Error: Out of proposal period
+error.thesisProposal.ParticipantNotIncludedException = Error: You must participate in a proposal created by you
 error.thesisProposal.participantType.delete.used = Error: Can't delete participant type: Currently being used
 error.thesisProposal.participantType.edit.used = Error: Can't edit participant type: Currently being used
 error.thesisProposal.TotalParticipantPercentageException = Total percentage should be 100

--- a/src/main/webapp/WEB-INF/resources/ThesisProposalsResources_en.properties
+++ b/src/main/webapp/WEB-INF/resources/ThesisProposalsResources_en.properties
@@ -42,6 +42,7 @@ error.thesisProposal.MaxNumberThesisProposalsException = Error: Maximum number o
 error.thesisProposal.NullPointerException = Error: Select thesis proposal no longer available
 error.thesisProposal.OutOfCandidacyPeriodException = Error: Out of candidacy period
 error.thesisProposal.OutOfProposalPeriodException = Error: Out of proposal period
+error.thesisProposal.ParticipantNotIncludedException = Error: You must participate in a proposal created by you
 error.thesisProposal.participantType.delete.used = Error: Can't delete participant type: Currently being used
 error.thesisProposal.participantType.edit.used = Error: Can't edit participant type: Currently being used
 error.thesisProposal.TotalParticipantPercentageException = Total percentage should be 100

--- a/src/main/webapp/WEB-INF/resources/ThesisProposalsResources_pt.properties
+++ b/src/main/webapp/WEB-INF/resources/ThesisProposalsResources_pt.properties
@@ -42,6 +42,7 @@ error.thesisProposal.MaxNumberThesisProposalsException = Erro: Número máximo d
 error.thesisProposal.NullPointerException = Erro: Proposta de tese já não disponível
 error.thesisProposal.OutOfCandidacyPeriodException = Erro: Fora do período de candidaturas.
 error.thesisProposal.OutOfProposalPeriodException = Erro: Fora do período de propostas.
+error.thesisProposal.ParticipantNotIncludedException = Erro: Tem de participar numa tese criada por si
 error.thesisProposal.participantType.delete.used = Erro: Não é possivel apagar tipo de participante. Tipo actualmente em uso.
 error.thesisProposal.participantType.edit.used = Erro: Não é possivel editar tipo de participante. Tipo actualmente em uso.
 error.thesisProposal.TotalParticipantPercentageException = O total da percentagem de participações deve ser 100


### PR DESCRIPTION
ThesisCreators should be present in the proposal created by them, except coordinators if the proposal is offered to the executionDegree they coordinate
