### PR TITLE
Setting seconds field to 0 in configurations periods THS-35 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/thesis/domain/ThesisProposalsConfiguration.java
+++ b/src/main/java/org/fenixedu/academic/thesis/domain/ThesisProposalsConfiguration.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.fenixedu.academic.domain.ExecutionDegree;
 import org.fenixedu.academic.domain.exceptions.DomainException;
 import org.fenixedu.bennu.core.i18n.BundleUtil;
+import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 public class ThesisProposalsConfiguration extends ThesisProposalsConfiguration_Base {
@@ -151,4 +152,21 @@ public class ThesisProposalsConfiguration extends ThesisProposalsConfiguration_B
 
         return builder.toString();
     }
+
+    @Override
+    public void setProposalPeriod(org.joda.time.Interval proposalPeriod) {
+        DateTime start = proposalPeriod.getStart().withSecondOfMinute(0);
+        DateTime end = proposalPeriod.getEnd().withSecondOfMinute(0);
+
+        super.setProposalPeriod(new org.joda.time.Interval(start, end));
+    }
+
+    @Override
+    public void setCandidacyPeriod(org.joda.time.Interval candidacyPeriod) {
+        DateTime start = candidacyPeriod.getStart().withSecondOfMinute(0);
+        DateTime end = candidacyPeriod.getEnd().withSecondOfMinute(0);
+
+        super.setCandidacyPeriod(new org.joda.time.Interval(start, end));
+    }
+
 }

--- a/src/main/webapp/WEB-INF/configuration/create.jsp
+++ b/src/main/webapp/WEB-INF/configuration/create.jsp
@@ -57,11 +57,11 @@ ${ portal.toolkit() }
     <label for="proposalPeriodEnd" class="col-sm-4 control-label"><spring:message code='label.proposalPeriod'/></label>
     <div class="col-sm-4">
       <label for="proposalPeriodStart"  class="col-sm-2 control-label"><spring:message code='label.start'/></label>
-      <input type="text" bennu-datetime name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodStart}'/>
+      <input type="text" bennu-datetime no-seconds name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodStart}'/>
     </div>
     <div class="col-sm-4">
       <label for="proposalPeriodEnd" path="proposalPeriodEnd" class="col-sm-2 control-label"><spring:message code='label.end'/></label>
-      <input type="text" bennu-datetime name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodEnd}'/>
+      <input type="text" bennu-datetime no-seconds name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodEnd}'/>
     </div>
   </div>
 
@@ -69,11 +69,11 @@ ${ portal.toolkit() }
     <label for="candidacyPeriodStart" class="col-sm-4 control-label"><spring:message code='label.candidacies'/></label>
     <div class="col-sm-4">
       <label for="candidacyPeriodStart"  class="col-sm-2 control-label"><spring:message code='label.start'/></label>
-      <input type="text" bennu-datetime name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodStart}'/>
+      <input type="text" bennu-datetime no-seconds name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodStart}'/>
     </div>
     <div class="col-sm-4">
       <label for="candidacyPeriodEnd" path="candidacyPeriodEnd" class="col-sm-2 control-label"><spring:message code='label.end'/></label>
-      <input type="text" bennu-datetime name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodEnd}'/>
+      <input type="text" bennu-datetime no-seconds name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodEnd}'/>
     </div>
   </div>
 

--- a/src/main/webapp/WEB-INF/configuration/edit.jsp
+++ b/src/main/webapp/WEB-INF/configuration/edit.jsp
@@ -65,11 +65,11 @@ ${ portal.toolkit() }
   <label for="proposalPeriodEnd" class="col-sm-4 control-label"><spring:message code='label.proposalPeriod'/></label>
   <div class="col-sm-4">
     <label for="proposalPeriodStart"  class="col-sm-2 control-label"><spring:message code='label.start'/></label>
-    <input type="text" bennu-datetime name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodStart}'/>
+    <input type="text" bennu-datetime no-seconds name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodStart}'/>
   </div>
   <div class="col-sm-4">
     <label for="proposalPeriodEnd" path="proposalPeriodEnd" class="col-sm-2 control-label"><spring:message code='label.end'/></label>
-    <input type="text" bennu-datetime name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodEnd}'/>
+    <input type="text" bennu-datetime no-seconds name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.proposalPeriodEnd}'/>
   </div>
 </div>
 
@@ -78,11 +78,11 @@ ${ portal.toolkit() }
   <label for="candidacyPeriodStart" class="col-sm-4 control-label"><spring:message code='label.candidacies'/></label>
   <div class="col-sm-4">
     <label for="candidacyPeriodStart"  class="col-sm-2 control-label"><spring:message code='label.start'/></label>
-    <input type="text" bennu-datetime name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodStart}'/>
+    <input type="text" bennu-datetime no-seconds name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodStart}'/>
   </div>
   <div class="col-sm-4">
     <label for="candidacyPeriodEnd" path="candidacyPeriodEnd" class="col-sm-2 control-label"><spring:message code='label.end'/></label>
-    <input type="text" bennu-datetime name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodEnd}'/>
+    <input type="text" bennu-datetime no-seconds name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" placeholder="<spring:message code='label.start'/>" required="required" value='${command.candidacyPeriodEnd}'/>
   </div>
 </div>
 

--- a/src/main/webapp/WEB-INF/configuration/list.jsp
+++ b/src/main/webapp/WEB-INF/configuration/list.jsp
@@ -192,11 +192,11 @@ $(".deleteConfiguration").on("click", function() {
 						<label for="proposalPeriodEnd" class="col-sm-4 control-label"><spring:message code='label.proposalPeriod'/></label>
 						<div class="col-sm-4">
 							<label for="proposalPeriodStart"  class="control-label"><spring:message code='label.start'/></label>
-							<input type="text" bennu-datetime name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" required="required" value='${thesisProposalsConfigurationBean.proposalPeriodStart}'/>
+							<input type="text" bennu-datetime no-seconds name="proposalPeriodStart" class="form-control" id="proposalPeriodStart" required="required" value='${thesisProposalsConfigurationBean.proposalPeriodStart}'/>
 						</div>
 						<div class="col-sm-4">
 							<label for="proposalPeriodEnd" path="proposalPeriodEnd" class="control-label"><spring:message code='label.end'/></label>
-							<input type="text" bennu-datetime name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" required="required" value='${thesisProposalsConfigurationBean.proposalPeriodEnd}'/>
+							<input type="text" bennu-datetime no-seconds name="proposalPeriodEnd" class="form-control" id="proposalPeriodEnd" required="required" value='${thesisProposalsConfigurationBean.proposalPeriodEnd}'/>
 						</div>
 					</div>
 
@@ -204,11 +204,11 @@ $(".deleteConfiguration").on("click", function() {
 						<label for="candidacyPeriodStart" class="col-sm-4 control-label"><spring:message code='label.candidacies'/></label>
 						<div class="col-sm-4">
 							<label for="candidacyPeriodStart"  class="control-label"><spring:message code='label.start'/></label>
-							<input type="text" bennu-datetime name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart"  required="required" value=''/>
+							<input type="text" bennu-datetime no-seconds name="candidacyPeriodStart" class="form-control" id="candidacyPeriodStart"  required="required" value=''/>
 						</div>
 						<div class="col-sm-4">
 							<label for="candidacyPeriodEnd" path="candidacyPeriodEnd" class="control-label"><spring:message code='label.end'/></label>
-							<input type="text" bennu-datetime name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" required="required" value=''/>
+							<input type="text" bennu-datetime no-seconds name="candidacyPeriodEnd" class="form-control" id="candidacyPeriodEnd" required="required" value=''/>
 						</div>
 					</div>
 


### PR DESCRIPTION
When creating or editing configurations periods, the interface no longer
supports editing the seconds field on the datetime input. The system
sets the seconds to 0.
