### PR TITLE
Fix thesis object creation on candidacy acceptance THS-63 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/thesis/ui/service/ThesisProposalsService.java
+++ b/src/main/java/org/fenixedu/academic/thesis/ui/service/ThesisProposalsService.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.fenixedu.academic.domain.Degree;
+import org.fenixedu.academic.domain.Enrolment;
 import org.fenixedu.academic.domain.ExecutionDegree;
 import org.fenixedu.academic.domain.ExecutionYear;
 import org.fenixedu.academic.domain.Teacher;
@@ -472,9 +473,16 @@ public class ThesisProposalsService {
                 .stream()
                 .forEach(
                         executionDegree -> {
-                            if (registration.getDissertationEnrolment() != null) {
+                            Enrolment dissertationEnrolment = registration.getDissertationEnrolment();
+
+                            ExecutionYear candidacyExecutionYear =
+                                    studentThesisCandidacy.getThesisProposal().getSingleThesisProposalsConfiguration()
+                                            .getExecutionDegree().getExecutionYear();
+
+                            if (dissertationEnrolment != null
+                                    && dissertationEnrolment.getExecutionYear() == candidacyExecutionYear) {
                                 if (registration.hasDissertationThesis()) {
-                                    Thesis thesis = registration.getDissertationEnrolment().getThesis();
+                                    Thesis thesis = dissertationEnrolment.getThesis();
                                     thesis.setTitle(new MultiLanguageString(proposal.getTitle()));
 
                                     thesis.getParticipationsSet()
@@ -496,8 +504,8 @@ public class ThesisProposalsService {
                                     }
                                 } else {
                                     Thesis thesis =
-                                            new Thesis(registration.getDegree(), registration.getDissertationEnrolment(),
-                                                    new MultiLanguageString(proposal.getTitle()));
+                                            new Thesis(registration.getDegree(), dissertationEnrolment, new MultiLanguageString(
+                                                    proposal.getTitle()));
 
                                     for (ThesisProposalParticipant participant : proposal.getThesisProposalParticipantSet()) {
                                         if (participant.getUser() != null) {


### PR DESCRIPTION
Previously creating/editing thesis object on candidacy acceptance if any dissertationEnrolment associated with registration.
Now comparing dissertationEnrolment executionYear and candidacy executionYear

> Perfect solution would match on academic interval, but not possible with current domain
