### PR TITLE
Fix candidacies details not showing correctly THS-101 #resolve

### DIFF
--- a/src/main/webapp/WEB-INF/studentCandidacies/list.jsp
+++ b/src/main/webapp/WEB-INF/studentCandidacies/list.jsp
@@ -93,14 +93,6 @@
 
 			}
 		} );
-		$('.existingCandidaciesTable').DataTable().on( 'draw', function () {
-			$(".detailsButton").on("click", function(evt){
-				var e = $(evt.target);
-				var tid = e.data('thesis');
-
-				$('#view').modal('show');
-			});
-		} );
 		// $('.dataTables_filter').remove();
 	});
 </script>
@@ -309,14 +301,8 @@ $(document).ready(function() {
 </style>
 
 <script type="text/javascript">
-jQuery(document).ready(function(){
-	jQuery('.detailsButton').on('click', function(event) {
-		$("#details" + $(this).data("thesis")).toggle('show');
-	});
-});
-
 $(function(){
-	$(".detailsButton").on("click", function(evt){
+	$(".existingCandidaciesTable tbody").on("click", ".detailsButton", function(evt){
 		var e = $(evt.target);
 		var tid = e.data('thesis');
 


### PR DESCRIPTION
Instead of having the event handler on each button, which is only registered for the items that are visible on page load (i.e. the first 50), this PR changes the handler to the table, avoiding the issue with the handler not being correctly registered for the hidden items.

This follows the documentation of the DataTable library used: https://www.datatables.net/examples/advanced_init/events_live.html